### PR TITLE
Use require_relative

### DIFF
--- a/lib/figo.rb
+++ b/lib/figo.rb
@@ -24,7 +24,7 @@ require "json"
 require "logger"
 require 'net/http/persistent'
 require "digest/sha1"
-require "./lib/models.rb"
+require_relative "models.rb"
 
 $logger = Logger.new(STDOUT)
 


### PR DESCRIPTION
It raise exception when used as a gem in ra rails project:

> /gems/activesupport-3.2.12/lib/active_support/dependencies.rb:251:in `require': cannot load such file -- ./lib/models.rb (LoadError)

Use require_relative instead of require fixed the issue.
