### PR TITLE
Transactions API - support more parameters as additional parameters

### DIFF
--- a/lib/figo.rb
+++ b/lib/figo.rb
@@ -373,9 +373,10 @@ module Figo
     #        in the response; pending transactions are always included as a complete set, regardless of
     #        the `since` parameter
     # @return [Array] an array of `Transaction` objects, one for each transaction of the user
-    def transactions(account_id = nil, since = nil, count = 1000, offset = 0, include_pending = false)
+    def transactions(account_id = nil, since = nil, count = 1000, offset = 0, include_pending = false, additional_params = {})
       data = {"count" => count.to_s, "offset" => offset.to_s, "include_pending" => include_pending ? "1" : "0"}
       data["since"] = ((since.is_a?(Date) ? since.to_s : since) unless since.nil?)
+      data.reverse_merge!(additional_params)
 
       query_api_object Transaction, (account_id.nil? ? "/rest/transactions?" : "/rest/accounts/#{account_id}/transactions?") + URI.encode_www_form(data), nil, "GET", "transactions"
     end

--- a/lib/models.rb
+++ b/lib/models.rb
@@ -207,8 +207,8 @@ module Figo
     #        in the response; pending transactions are always included as a complete set, regardless of
     #        the `since` parameter
     # @return [Array] an array of `Transaction` objects, one for each transaction of this account
-    def transactions(since = nil, count = 1000, offset = 0, include_pending = false)
-      @session.transactions @account_id, since, count, offset, include_pending
+    def transactions(since = nil, count = 1000, offset = 0, include_pending = false, additional_parameters = {})
+      @session.transactions @account_id, since, count, offset, include_pending, additional_parameters
     end
 
     # Request specific transaction.


### PR DESCRIPTION
Transactions API - support more parameters as additional parameters.
This will enable extra parameters to be sent, like **since_type** for example.