### PR TITLE
Added `Security` model.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,6 @@ rvm:
   - 2.0.0
   - 2.1.1
   - ruby-head
+install:
+  - "gem install bundler"
+  - "bundle install --jobs=3 --retry=3"

--- a/lib/figo.rb
+++ b/lib/figo.rb
@@ -494,5 +494,12 @@ module Figo
     def remove_payment(payment)
       query_api "/rest/accounts/#{payment.account_id}/payments/#{payment.payment_id}", nil, "DELETE"
     end
+
+    # Retrieve securities of all of the user's accounts
+    #
+    # @return [Security] an array of `Security` objects
+    def securities
+      query_api_object Security, "/rest/securities", nil, "GET", "securities"
+    end
   end
 end

--- a/lib/models.rb
+++ b/lib/models.rb
@@ -47,6 +47,12 @@ module Figo
         amount balance
         credit_line
         monthly_spending_limit
+        quantity
+        amount
+        amount_original_currency
+        exchange_rate
+        price
+        purchase_price
       )
 
       hash.each do |key, value|
@@ -468,5 +474,86 @@ module Figo
     # ID of the transaction corresponding to this payment. This field is only set if the payment has been matched to a transaction
     # @return [String]
     attr_accessor :transaction_id
+  end
+
+  # Object representing a depot security
+  class Security < Base
+    @dump_attributes = []
+
+    # Internal figo Connect security ID
+    # @return [String]
+    attr_accessor :security_id
+
+    # Internal figo Connect account ID
+    # @return [String]
+    attr_accessor :account_id
+
+    # Name of the security
+    # @return [String]
+    attr_accessor :name
+
+    # International Securities Identification Number
+    # @return [String]
+    attr_accessor :isin
+
+    # Wertpapierkennnummer (if available)
+    # @return [String]
+    attr_accessor :wkn
+
+    # Market name
+    # @return [String]
+    attr_accessor :market
+
+    # Three-character currency code when measured in currency (and not pieces)
+    # @return [String]
+    attr_accessor :currency
+
+    # Number of pieces or value
+    # @return [Number]
+    attr_accessor :quantity
+
+    # Monetary value in account currency
+    # @return [Number]
+    attr_accessor :amount
+
+    # Monetary value in trading currency
+    # @return [Number]
+    attr_accessor :amount_original_currency
+
+    # Exchange rate between trading and account currency
+    # @return [Number]
+    attr_accessor :exchange_rate
+
+    # Current price
+    # @return [Number]
+    attr_accessor :price
+
+    # Currency of current price
+    # @return [String]
+    attr_accessor :price_currency
+
+    # Purchase price
+    # @return [Number]
+    attr_accessor :purchase_price
+
+    # Currency of purchase price
+    # @return [String]
+    attr_accessor :purchase_price_currency
+
+    # This flag indicates whether the security has already been marked as visited by the user
+    # @return [Boolean]
+    attr_accessor :visited
+
+    # Trading timestamp
+    # @return [String]
+    attr_accessor :trade_timestamp
+
+    # Internal creation timestamp on the figo Connect server
+    # @return [String]
+    attr_accessor :creation_timestamp
+
+    # Internal modification timestamp on the figo Connect server
+    # @return [String]
+    attr_accessor :modification_timestamp
   end
 end

--- a/lib/models.rb
+++ b/lib/models.rb
@@ -43,6 +43,12 @@ module Figo
     def initialize(session, hash)
       @session = session
 
+      decnum_keys = %w(
+        amount balance
+        credit_line
+        monthly_spending_limit
+      )
+
       hash.each do |key, value|
         key = key.to_s if key.is_a? Symbol
         next unless respond_to? "#{key}="
@@ -52,7 +58,7 @@ module Figo
           value = SynchronizationStatus.new(session, value)
         elsif key == "balance" and value.is_a? Hash
           value = AccountBalance.new(session, value)
-        elsif key == "amount" or key == "balance" or key == "credit_line" or key == "monthly_spending_limit"
+        elsif decnum_keys.include? key
           value = Flt::DecNum(value.to_s)
         elsif key.end_with?("_date")
           value = DateTime.iso8601(value)


### PR DESCRIPTION
I guess it makes sense to include this in the official library.

The approach to define which keys' values should be treated as which type has its limitations, though. Maybe a per-model list of `(key, type_function)` pairs is more flexible?

While I was able to fetch all available securities for all of the current user's accounts via `session.query_api_object Security, '/rest/securities', nil, 'GET', 'securities'`, this approach ignores other keys besides `"securities"` in the JSON response (namely `"deleted"` and `"status"`); the Ruby library does not seem to provide an easy way to handle those as well. This is why I haven't added any methods to the session class, yet.
Then again, the [equivalent method in the Python library](https://github.com/figo-connect/python-figo/blob/master/figo/figo.py#L828) seems to ignore the other keys as well.
